### PR TITLE
feat: Serve static images for NFT metadata

### DIFF
--- a/packages/backend/public/images/nfts/badges/.gitkeep
+++ b/packages/backend/public/images/nfts/badges/.gitkeep
@@ -1,0 +1,1 @@
+# Place your badge images here, e.g., a1.png, a2.png, ..., c2.png

--- a/packages/backend/public/images/nfts/certificates/.gitkeep
+++ b/packages/backend/public/images/nfts/certificates/.gitkeep
@@ -1,0 +1,1 @@
+# Place your certificate images here, e.g., a1.png, a2.png, ..., c2.png

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -16,7 +16,12 @@ import { initializeSbtListeners } from './services/sbtListenerService'; // New S
 const app = express();
 const port = process.env.PORT || 3001;
 
+// Middleware to parse JSON bodies
 app.use(express.json());
+
+// Middleware to serve static files from the 'public' directory
+// This will allow access to files like http://localhost:3001/images/nfts/badges/a1.png
+app.use(express.static('public'));
 
 // Root endpoint
 app.get('/', (req: Request, res: Response) => {

--- a/packages/backend/src/routes/nftMetadataRoutes.ts
+++ b/packages/backend/src/routes/nftMetadataRoutes.ts
@@ -12,14 +12,15 @@ const getStaticNftMetadata = (level: string, type: 'Badge' | 'Certificate', toke
     return null; // Invalid level
   }
 
+  const apiBaseUrl = process.env.API_BASE_URL || 'http://localhost:3001'; // Fallback to localhost if not set
+
   // Customize this metadata as needed. This is just a placeholder structure.
   // In a real scenario, these details would be more specific to your NFTs.
   const metadata = {
     name: `${type} of ${lowerLevel.toUpperCase()} Completion`,
     description: `This ${type.toLowerCase()} certifies (or represents) the completion of the ${lowerLevel.toUpperCase()} language level. Token ID: ${tokenId}.`,
-    image: `https://example.com/images/nfts/${type.toLowerCase()}/${lowerLevel}/${tokenId}.png`, // Placeholder dynamic image URL based on type, level, and tokenID
-    // You can also have a static image per level:
-    // image: `https://example.com/images/nfts/${type.toLowerCase()}/${lowerLevel}.png`,
+    // Construct image URL using API_BASE_URL and conventional path
+    image: `${apiBaseUrl}/images/nfts/${type.toLowerCase()}s/${lowerLevel}.png`, // e.g., https://hackathon.omerharuncetin.com/images/nfts/badges/a1.png
     attributes: [
       {
         trait_type: "Level",


### PR DESCRIPTION
- Adds API_BASE_URL to .env for constructing full image URLs.
- Creates directory structure public/images/nfts/badges/ and public/images/nfts/certificates/ for storing NFT images.
- Configures Express to serve static files from the 'public' directory.
- Updates NFT metadata generation in nftMetadataRoutes.ts to use API_BASE_URL and point to locally served images (e.g., /images/nfts/badges/a1.png).

User needs to place actual image files in the created public/images directories and ensure API_BASE_URL is correctly set in their environment.