### PR TITLE
feat: Implement frontend hooks layer for API services

### DIFF
--- a/packages/app/src/app/hooks/useAvatarHooks.ts
+++ b/packages/app/src/app/hooks/useAvatarHooks.ts
@@ -1,0 +1,53 @@
+// packages/app/src/app/hooks/useAvatarHooks.ts
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+import { useAccount } from 'wagmi';
+import { API_URL } from '../config';
+
+// Types
+interface Avatar {
+  id: string;
+  name: string;
+  description?: string;
+  price: number;
+  imageUrl: string;
+  lessons: number; // Assuming lessons is part of Avatar schema based on nftMetadataRoutes
+  // ... other avatar fields
+}
+
+const AVATAR_QUERY_KEY = 'avatars';
+
+// Axios instance for API calls
+const apiClient = axios.create({
+  baseURL: API_URL,
+});
+
+// GET /api/avatars - Get all available avatars
+export const useGetAvatars = () => {
+  const { isConnected } = useAccount();
+  return useQuery<Avatar[], Error>({
+    queryKey: [AVATAR_QUERY_KEY],
+    queryFn: async () => {
+      const { data } = await apiClient.get('/api/avatars');
+      return data;
+    },
+    // Avatars can typically be fetched even if not connected,
+    // unless there's a specific reason to restrict.
+    // enabled: isConnected,
+  });
+};
+
+// GET /api/avatars/:id - Get a specific avatar by ID
+export const useGetAvatarById = (avatarId?: string) => {
+  const { isConnected } = useAccount();
+  return useQuery<Avatar, Error>({
+    queryKey: [AVATAR_QUERY_KEY, avatarId],
+    queryFn: async () => {
+      if (!avatarId) throw new Error('Avatar ID is required');
+      const { data } = await apiClient.get(`/api/avatars/${avatarId}`);
+      return data;
+    },
+    enabled: !!avatarId, // Fetch if avatarId is provided
+    // enabled: isConnected && !!avatarId, // If connection is also required
+  });
+};

--- a/packages/app/src/app/hooks/useBadgeHooks.ts
+++ b/packages/app/src/app/hooks/useBadgeHooks.ts
@@ -1,0 +1,115 @@
+// packages/app/src/app/hooks/useBadgeHooks.ts
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import axios from 'axios';
+import { useAccount } from 'wagmi';
+import { API_URL } from '../config';
+
+// Types
+interface Badge {
+  id: string;
+  userId: string;
+  languageLevel: string;
+  badgeUrl?: string; // Based on sbtListenerService, might be generated
+  tokenId?: string;  // Based on sbtListenerService
+  issueDate: Date;
+  // ... other badge fields
+}
+
+interface AwardBadgePayload {
+  languageLevel: string;
+  badgeAddress: string; // This comes from the backend's BlockchainService interaction
+}
+
+interface GenericBadgeInfo {
+  message: string;
+  level: string;
+  imageUrl: string;
+}
+
+const BADGE_QUERY_KEY_PREFIX = 'badges';
+
+// Axios instance for API calls
+const apiClient = axios.create({
+  baseURL: API_URL,
+});
+
+// --- User-specific Badge Hooks ---
+
+// GET /api/users/:userId/badges - Get all badges for a user
+export const useGetUserBadges = (userId?: string, languageLevel?: string) => {
+  const { address, isConnected } = useAccount();
+  const enabled = isConnected && !!userId && (userId === 'me' || !!address); // 'me' could be a placeholder for connected user
+
+  return useQuery<Badge[], Error>({
+    queryKey: [BADGE_QUERY_KEY_PREFIX, 'user', userId, { languageLevel }],
+    queryFn: async () => {
+      if (!userId) throw new Error('User ID is required');
+      // Replace 'me' with actual connected user's ID if that pattern is used.
+      // For now, assuming userId is always specific or handled by backend if it's a general 'me'.
+      const actualUserId = userId; // Potentially map 'me' to a real ID if needed client-side
+
+      const { data } = await apiClient.get(`/api/users/${actualUserId}/badges`, {
+        params: { languageLevel },
+      });
+      return data;
+    },
+    enabled: !!userId, // Only fetch if userId is provided
+  });
+};
+
+// POST /api/users/:userId/badges - Award a badge to a user
+export const useAwardBadge = () => {
+  const queryClient = useQueryClient();
+  const { address, isConnected } = useAccount();
+
+  return useMutation<Badge, Error, { userId: string; payload: AwardBadgePayload }>({
+    mutationFn: async ({ userId, payload }) => {
+      if (!isConnected || !address) {
+        throw new Error('User not connected');
+      }
+      // Optional: Add check if connected user is the one receiving the badge, if applicable
+      const { data } = await apiClient.post(`/api/users/${userId}/badges`, payload);
+      return data;
+    },
+    onSuccess: (awardedBadge, variables) => {
+      queryClient.invalidateQueries({ queryKey: [BADGE_QUERY_KEY_PREFIX, 'user', variables.userId] });
+      // Potentially invalidate user query if badges are nested there
+      queryClient.invalidateQueries({ queryKey: ['users', variables.userId] });
+    },
+  });
+};
+
+// DELETE /api/users/:userId/badges/:badgeId - Delete a specific badge award
+export const useDeleteUserBadge = () => {
+  const queryClient = useQueryClient();
+  const { address, isConnected } = useAccount();
+
+  return useMutation<void, Error, { userId: string; badgeId: string }>({
+    mutationFn: async ({ userId, badgeId }) => {
+      if (!isConnected || !address) {
+        throw new Error('User not connected');
+      }
+      await apiClient.delete(`/api/users/${userId}/badges/${badgeId}`);
+    },
+    onSuccess: (data, variables) => {
+      queryClient.invalidateQueries({ queryKey: [BADGE_QUERY_KEY_PREFIX, 'user', variables.userId] });
+      queryClient.invalidateQueries({ queryKey: ['users', variables.userId] });
+    },
+  });
+};
+
+// --- Generic Badge Info Hook ---
+
+// GET /api/badges/:level - Get generic badge information for a level
+export const useGetGenericBadgeInfo = (level?: string) => {
+  // This is public info, so connection state might not be strictly necessary for enabling.
+  return useQuery<GenericBadgeInfo, Error>({
+    queryKey: [BADGE_QUERY_KEY_PREFIX, 'generic', level],
+    queryFn: async () => {
+      if (!level) throw new Error('Language level is required');
+      const { data } = await apiClient.get(`/api/badges/${level}`);
+      return data;
+    },
+    enabled: !!level, // Only fetch if level is provided
+  });
+};

--- a/packages/app/src/app/hooks/useCertificateHooks.ts
+++ b/packages/app/src/app/hooks/useCertificateHooks.ts
@@ -1,0 +1,111 @@
+// packages/app/src/app/hooks/useCertificateHooks.ts
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import axios from 'axios';
+import { useAccount } from 'wagmi';
+import { API_URL } from '../config';
+
+// Types
+interface Certificate {
+  id: string;
+  userId: string;
+  languageLevel: string;
+  certificateUrl: string;
+  tokenId?: string;
+  issueDate: Date;
+  // ... other certificate fields
+}
+
+interface AwardCertificatePayload {
+  languageLevel: string;
+  certificateUrl: string;
+  tokenId?: string;
+}
+
+interface GenericCertificateInfo {
+  message: string;
+  level: string;
+  imageUrl: string;
+}
+
+const CERTIFICATE_QUERY_KEY_PREFIX = 'certificates';
+
+// Axios instance for API calls
+const apiClient = axios.create({
+  baseURL: API_URL,
+});
+
+// --- User-specific Certificate Hooks ---
+
+// GET /api/users/:userId/certificates - Get all certificates for a user
+export const useGetUserCertificates = (userId?: string, languageLevel?: string) => {
+  const { address, isConnected } = useAccount();
+  // Enable if connected and userId is provided.
+  // Could add logic for 'me' to map to connected user's ID if needed.
+  const enabled = isConnected && !!userId;
+
+  return useQuery<Certificate[], Error>({
+    queryKey: [CERTIFICATE_QUERY_KEY_PREFIX, 'user', userId, { languageLevel }],
+    queryFn: async () => {
+      if (!userId) throw new Error('User ID is required');
+      const { data } = await apiClient.get(`/api/users/${userId}/certificates`, {
+        params: { languageLevel },
+      });
+      return data;
+    },
+    enabled: !!userId,
+  });
+};
+
+// POST /api/users/:userId/certificates - Award a certificate to a user
+export const useAwardCertificate = () => {
+  const queryClient = useQueryClient();
+  const { address, isConnected } = useAccount();
+
+  return useMutation<Certificate, Error, { userId: string; payload: AwardCertificatePayload }>({
+    mutationFn: async ({ userId, payload }) => {
+      if (!isConnected || !address) {
+        throw new Error('User not connected');
+      }
+      const { data } = await apiClient.post(`/api/users/${userId}/certificates`, payload);
+      return data;
+    },
+    onSuccess: (awardedCertificate, variables) => {
+      queryClient.invalidateQueries({ queryKey: [CERTIFICATE_QUERY_KEY_PREFIX, 'user', variables.userId] });
+      queryClient.invalidateQueries({ queryKey: ['users', variables.userId] }); // If user object embeds certificates
+    },
+  });
+};
+
+// DELETE /api/users/:userId/certificates/:certificateId - Delete a specific certificate award
+export const useDeleteUserCertificate = () => {
+  const queryClient = useQueryClient();
+  const { address, isConnected } = useAccount();
+
+  return useMutation<void, Error, { userId: string; certificateId: string }>({
+    mutationFn: async ({ userId, certificateId }) => {
+      if (!isConnected || !address) {
+        throw new Error('User not connected');
+      }
+      await apiClient.delete(`/api/users/${userId}/certificates/${certificateId}`);
+    },
+    onSuccess: (data, variables) => {
+      queryClient.invalidateQueries({ queryKey: [CERTIFICATE_QUERY_KEY_PREFIX, 'user', variables.userId] });
+      queryClient.invalidateQueries({ queryKey: ['users', variables.userId] });
+    },
+  });
+};
+
+// --- Generic Certificate Info Hook ---
+
+// GET /api/certificates/:level - Get generic certificate information for a level
+export const useGetGenericCertificateInfo = (level?: string) => {
+  return useQuery<GenericCertificateInfo, Error>({
+    queryKey: [CERTIFICATE_QUERY_KEY_PREFIX, 'generic', level],
+    queryFn: async () => {
+      if (!level) throw new Error('Language level is required');
+      const { data } = await apiClient.get(`/api/certificates/${level}`);
+      return data;
+    },
+    enabled: !!level, // Only fetch if level is provided
+  });
+};

--- a/packages/app/src/app/hooks/useLeaderboardHooks.ts
+++ b/packages/app/src/app/hooks/useLeaderboardHooks.ts
@@ -1,0 +1,133 @@
+// packages/app/src/app/hooks/useLeaderboardHooks.ts
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import axios from 'axios';
+import { useAccount } from 'wagmi'; // To control mutations based on connection
+import { API_URL } from '../config';
+
+// Types
+interface UserForLeaderboard {
+  username?: string;
+  walletAddress: string;
+}
+
+interface LeaderboardEntry {
+  id: string;
+  userId: string;
+  language: string;
+  points: number;
+  createdAt: Date;
+  updatedAt: Date;
+  user: UserForLeaderboard;
+}
+
+interface LeaderboardResponse {
+  data: LeaderboardEntry[];
+  page: number;
+  limit: number;
+  totalPages: number;
+  totalEntries: number;
+}
+
+interface CreateLeaderboardEntryPayload {
+  userId: string;
+  language: string;
+  points: number;
+}
+
+interface UpdateLeaderboardEntryPayload {
+  points: number;
+}
+
+const LEADERBOARD_QUERY_KEY = 'leaderboardEntries';
+
+// Axios instance for API calls
+const apiClient = axios.create({
+  baseURL: API_URL,
+});
+
+// GET /api/leaderboard - Get leaderboard entries
+export const useGetLeaderboardEntries = (params?: {
+  language?: string;
+  sortBy?: 'points' | 'createdAt' | 'updatedAt';
+  order?: 'asc' | 'desc';
+  limit?: number;
+  page?: number;
+}) => {
+  // Leaderboard is public, so connection status might not be needed for query enabling
+  return useQuery<LeaderboardResponse, Error>({
+    queryKey: [LEADERBOARD_QUERY_KEY, params],
+    queryFn: async () => {
+      const { data } = await apiClient.get('/api/leaderboard', { params });
+      return data;
+    },
+    // keepPreviousData: true, // Optional: for smoother pagination
+  });
+};
+
+// GET /api/leaderboard/:id - Get a specific leaderboard entry by its own ID
+export const useGetLeaderboardEntryById = (entryId?: string) => {
+  return useQuery<LeaderboardEntry, Error>({
+    queryKey: [LEADERBOARD_QUERY_KEY, entryId],
+    queryFn: async () => {
+      if (!entryId) throw new Error('Leaderboard entry ID is required');
+      const { data } = await apiClient.get(`/api/leaderboard/${entryId}`);
+      return data;
+    },
+    enabled: !!entryId,
+  });
+};
+
+// POST /api/leaderboard - Add or update a leaderboard entry
+export const useCreateOrUpdateLeaderboardEntry = () => {
+  const queryClient = useQueryClient();
+  const { isConnected } = useAccount();
+
+  return useMutation<LeaderboardEntry, Error, CreateLeaderboardEntryPayload>({
+    mutationFn: async (payload) => {
+      if (!isConnected) throw new Error('User not connected. Cannot update leaderboard.');
+      const { data } = await apiClient.post('/api/leaderboard', payload);
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [LEADERBOARD_QUERY_KEY] });
+    },
+  });
+};
+
+// PUT /api/leaderboard/:id - Update a leaderboard entry's points
+export const useUpdateLeaderboardEntry = () => {
+  const queryClient = useQueryClient();
+  const { isConnected } = useAccount();
+
+  return useMutation<LeaderboardEntry, Error, { entryId: string; payload: UpdateLeaderboardEntryPayload }>({
+    mutationFn: async ({ entryId, payload }) => {
+      if (!isConnected) throw new Error('User not connected. Cannot update leaderboard entry.');
+      const { data } = await apiClient.put(`/api/leaderboard/${entryId}`, payload);
+      return data;
+    },
+    onSuccess: (updatedEntry) => {
+      queryClient.invalidateQueries({ queryKey: [LEADERBOARD_QUERY_KEY] });
+      // Optionally update the specific entry in cache
+      queryClient.setQueryData([LEADERBOARD_QUERY_KEY, updatedEntry.id], updatedEntry);
+    },
+  });
+};
+
+// DELETE /api/leaderboard/:id - Delete a leaderboard entry
+export const useDeleteLeaderboardEntry = () => {
+  const queryClient = useQueryClient();
+  const { isConnected } = useAccount();
+
+  return useMutation<void, Error, string>({ // string is entryId
+    mutationFn: async (entryId) => {
+      if (!isConnected) throw new Error('User not connected. Cannot delete leaderboard entry.');
+      // Usually, only admins would do this. The hook itself doesn't enforce role,
+      // but the component calling it or the backend should.
+      await apiClient.delete(`/api/leaderboard/${entryId}`);
+    },
+    onSuccess: (data, entryId) => {
+      queryClient.invalidateQueries({ queryKey: [LEADERBOARD_QUERY_KEY] });
+      // queryClient.removeQueries({ queryKey: [LEADERBOARD_QUERY_KEY, entryId] }); // Also an option
+    },
+  });
+};

--- a/packages/app/src/app/hooks/useNftMetadataHooks.ts
+++ b/packages/app/src/app/hooks/useNftMetadataHooks.ts
@@ -1,0 +1,66 @@
+// packages/app/src/app/hooks/useNftMetadataHooks.ts
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+// import { useAccount } from 'wagmi'; // Not strictly needed if metadata is public
+import { API_URL } from '../config';
+
+// Basic NFT Metadata Type (adjust based on actual structure)
+interface NftAttribute {
+  trait_type: string;
+  value: string | number;
+}
+
+interface NftMetadata {
+  name: string;
+  description: string;
+  image: string;
+  attributes: NftAttribute[];
+  external_url?: string;
+  // ... other metadata fields
+}
+
+const NFT_METADATA_QUERY_KEY_PREFIX = 'nftMetadata';
+
+// Axios instance for API calls
+const apiClient = axios.create({
+  baseURL: API_URL,
+});
+
+// GET /api/nft/badges/:level/:tokenId
+export const useGetBadgeNftMetadata = (level?: string, tokenId?: string) => {
+  return useQuery<NftMetadata, Error>({
+    queryKey: [NFT_METADATA_QUERY_KEY_PREFIX, 'badge', level, tokenId],
+    queryFn: async () => {
+      if (!level || !tokenId) throw new Error('Level and Token ID are required');
+      const { data } = await apiClient.get(`/api/nft/badges/${level.toLowerCase()}/${tokenId}`);
+      return data;
+    },
+    enabled: !!level && !!tokenId,
+  });
+};
+
+// GET /api/nft/certificates/:level/:tokenId
+export const useGetCertificateNftMetadata = (level?: string, tokenId?: string) => {
+  return useQuery<NftMetadata, Error>({
+    queryKey: [NFT_METADATA_QUERY_KEY_PREFIX, 'certificate', level, tokenId],
+    queryFn: async () => {
+      if (!level || !tokenId) throw new Error('Level and Token ID are required');
+      const { data } = await apiClient.get(`/api/nft/certificates/${level.toLowerCase()}/${tokenId}`);
+      return data;
+    },
+    enabled: !!level && !!tokenId,
+  });
+};
+
+// GET /api/nft/avatars/:avatar_slug/:tokenId
+export const useGetAvatarNftMetadata = (avatarSlug?: string, tokenId?: string) => {
+  return useQuery<NftMetadata, Error>({
+    queryKey: [NFT_METADATA_QUERY_KEY_PREFIX, 'avatar', avatarSlug, tokenId],
+    queryFn: async () => {
+      if (!avatarSlug || !tokenId) throw new Error('Avatar slug and Token ID are required');
+      const { data } = await apiClient.get(`/api/nft/avatars/${avatarSlug.toLowerCase()}/${tokenId}`);
+      return data;
+    },
+    enabled: !!avatarSlug && !!tokenId,
+  });
+};

--- a/packages/app/src/app/hooks/useUserAvatarHooks.ts
+++ b/packages/app/src/app/hooks/useUserAvatarHooks.ts
@@ -1,0 +1,95 @@
+// packages/app/src/app/hooks/useUserAvatarHooks.ts
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import axios from 'axios';
+import { useAccount } from 'wagmi';
+import { API_URL } from '../config';
+
+// Types
+// Assuming Avatar type is defined elsewhere or we define a basic one here
+interface Avatar {
+  id: string;
+  name: string;
+  description?: string;
+  price: number;
+  imageUrl: string;
+  // ... other avatar fields
+}
+
+interface UserAvatar {
+  id: string; // This is the UserAvatar record ID
+  userId: string;
+  avatarId: string;
+  purchaseDate: Date;
+  avatar: Avatar; // Nested avatar details
+}
+
+interface RecordUserAvatarPayload {
+  avatarId: string;
+}
+
+const USER_AVATAR_QUERY_KEY_PREFIX = 'userAvatars';
+
+// Axios instance for API calls
+const apiClient = axios.create({
+  baseURL: API_URL,
+});
+
+// GET /api/users/:userId/avatars - Get all avatars owned by a user
+export const useGetUserAvatars = (userId?: string) => {
+  const { address, isConnected } = useAccount();
+  // Enable if connected and userId is provided.
+  // Could add logic for 'me' to map to connected user's ID.
+  const enabled = isConnected && !!userId;
+
+  return useQuery<UserAvatar[], Error>({
+    queryKey: [USER_AVATAR_QUERY_KEY_PREFIX, userId],
+    queryFn: async () => {
+      if (!userId) throw new Error('User ID is required');
+      const { data } = await apiClient.get(`/api/users/${userId}/avatars`);
+      return data;
+    },
+    enabled: enabled,
+  });
+};
+
+// POST /api/users/:userId/avatars - Record a user purchasing/owning an avatar
+export const useRecordUserAvatar = () => {
+  const queryClient = useQueryClient();
+  const { address, isConnected } = useAccount();
+
+  return useMutation<UserAvatar, Error, { userId: string; payload: RecordUserAvatarPayload }>({
+    mutationFn: async ({ userId, payload }) => {
+      if (!isConnected || !address) {
+        throw new Error('User not connected');
+      }
+      // Optional: Check if the connected user matches userId if that's a requirement
+      const { data } = await apiClient.post(`/api/users/${userId}/avatars`, payload);
+      return data;
+    },
+    onSuccess: (newUserAvatar, variables) => {
+      // Invalidate the list of user's avatars
+      queryClient.invalidateQueries({ queryKey: [USER_AVATAR_QUERY_KEY_PREFIX, variables.userId] });
+      // If user details query embeds their avatars, invalidate that too
+      queryClient.invalidateQueries({ queryKey: ['users', variables.userId] });
+    },
+  });
+};
+
+// DELETE /api/users/:userId/avatars/:userAvatarId - Remove an avatar ownership entry
+export const useDeleteUserAvatar = () => {
+  const queryClient = useQueryClient();
+  const { address, isConnected } = useAccount();
+
+  return useMutation<void, Error, { userId: string; userAvatarId: string }>({
+    mutationFn: async ({ userId, userAvatarId }) => {
+      if (!isConnected || !address) {
+        throw new Error('User not connected');
+      }
+      await apiClient.delete(`/api/users/${userId}/avatars/${userAvatarId}`);
+    },
+    onSuccess: (data, variables) => {
+      queryClient.invalidateQueries({ queryKey: [USER_AVATAR_QUERY_KEY_PREFIX, variables.userId] });
+      queryClient.invalidateQueries({ queryKey: ['users', variables.userId] });
+    },
+  });
+};

--- a/packages/app/src/app/hooks/useUserHooks.ts
+++ b/packages/app/src/app/hooks/useUserHooks.ts
@@ -1,0 +1,185 @@
+// packages/app/src/app/hooks/useUserHooks.ts
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import axios from 'axios';
+import { useAccount } from 'wagmi';
+import { API_URL } from '../config';
+
+// Types (Ideally, these would be shared from a common types directory or generated from OpenAPI spec)
+// For now, we'll define basic interfaces here.
+interface User {
+  id: string;
+  walletAddress: string;
+  username?: string;
+  // ... other user fields from your Prisma schema
+  progress?: any[];
+  leaderboard?: any[];
+  avatars?: any[];
+  certificates?: any[];
+  badges?: any[];
+  equippedAvatar?: any;
+  dailyLessonRecordToday?: any;
+}
+
+interface CreateUserPayload {
+  walletAddress: string;
+  username?: string;
+}
+
+interface UpdateUserPayload {
+  username: string;
+}
+
+interface CompleteLessonPayload {
+  languageLevel: string;
+}
+
+interface EquipAvatarPayload {
+  userAvatarId: string;
+}
+
+const USER_QUERY_KEY = 'users';
+
+// Axios instance for API calls
+const apiClient = axios.create({
+  baseURL: API_URL,
+});
+
+// GET /api/users - Get all users (filterable by walletAddress)
+export const useGetUsers = (walletAddress?: string) => {
+  const { address: connectedWalletAddress, isConnected } = useAccount();
+  return useQuery<User[], Error>({
+    queryKey: [USER_QUERY_KEY, { walletAddress }],
+    queryFn: async () => {
+      const { data } = await apiClient.get('/api/users', {
+        params: { walletAddress },
+      });
+      return data;
+    },
+    enabled: isConnected, // Only fetch if user is connected
+  });
+};
+
+// GET /api/users/:id - Get a specific user by ID
+export const useGetUserById = (userId?: string) => {
+  const { address, isConnected } = useAccount();
+  return useQuery<User, Error>({
+    queryKey: [USER_QUERY_KEY, userId],
+    queryFn: async () => {
+      if (!userId) throw new Error('User ID is required');
+      const { data } = await apiClient.get(`/api/users/${userId}`);
+      return data;
+    },
+    enabled: isConnected && !!userId, // Only fetch if connected and userId is provided
+  });
+};
+
+// POST /api/users - Create a new user
+export const useCreateUser = () => {
+  const queryClient = useQueryClient();
+  const { address, isConnected } = useAccount();
+
+  return useMutation<User, Error, CreateUserPayload>({
+    mutationFn: async (payload) => {
+      if (!isConnected || !address) {
+        throw new Error('User not connected');
+      }
+      // Ensure the payload's walletAddress matches the connected address if that's a requirement
+      // Or, if walletAddress in payload can be different, adjust logic.
+      // For creating a user, often the payload.walletAddress IS the new user's address.
+      // Here, we assume payload.walletAddress is the one to create.
+      const { data } = await apiClient.post('/api/users', payload);
+      return data;
+    },
+    onSuccess: (newUser) => {
+      queryClient.invalidateQueries({ queryKey: [USER_QUERY_KEY] });
+      // Optionally, update cache directly for the new user
+      queryClient.setQueryData([USER_QUERY_KEY, newUser.id], newUser);
+    },
+    //onError: (error) => { console.error("Failed to create user:", error); }
+  });
+};
+
+// PUT /api/users/:id - Update a user's username
+export const useUpdateUser = () => {
+  const queryClient = useQueryClient();
+  const { address, isConnected } = useAccount();
+
+  return useMutation<User, Error, { userId: string; payload: UpdateUserPayload }>({
+    mutationFn: async ({ userId, payload }) => {
+      if (!isConnected || !address) {
+        throw new Error('User not connected');
+      }
+      // Optional: Check if the connected user is the one being updated
+      // if (address !== userToUpdate.walletAddress) throw new Error("Unauthorized");
+      const { data } = await apiClient.put(`/api/users/${userId}`, payload);
+      return data;
+    },
+    onSuccess: (updatedUser) => {
+      queryClient.invalidateQueries({ queryKey: [USER_QUERY_KEY] });
+      queryClient.invalidateQueries({ queryKey: [USER_QUERY_KEY, updatedUser.id] });
+      queryClient.setQueryData([USER_QUERY_KEY, updatedUser.id], updatedUser);
+    },
+  });
+};
+
+// DELETE /api/users/:id - Delete a user
+export const useDeleteUser = () => {
+  const queryClient = useQueryClient();
+  const { address, isConnected } = useAccount();
+
+  return useMutation<void, Error, string>({ // string is userId
+    mutationFn: async (userId) => {
+      if (!isConnected || !address) {
+        throw new Error('User not connected');
+      }
+      await apiClient.delete(`/api/users/${userId}`);
+    },
+    onSuccess: (data, userId) => {
+      queryClient.invalidateQueries({ queryKey: [USER_QUERY_KEY] });
+      queryClient.invalidateQueries({ queryKey: [USER_QUERY_KEY, userId] });
+    },
+  });
+};
+
+// POST /api/users/:userId/complete-lesson
+export const useCompleteLesson = () => {
+  const queryClient = useQueryClient();
+  const { address, isConnected } = useAccount();
+
+  return useMutation<any, Error, { userId: string; payload: CompleteLessonPayload }>({
+    mutationFn: async ({ userId, payload }) => {
+      if (!isConnected || !address) {
+        throw new Error('User not connected');
+      }
+      const { data } = await apiClient.post(`/api/users/${userId}/complete-lesson`, payload);
+      return data;
+    },
+    onSuccess: (data, variables) => {
+      // Invalidate user data as it might include points, progress, daily limits
+      queryClient.invalidateQueries({ queryKey: [USER_QUERY_KEY, variables.userId] });
+      // Invalidate leaderboard if lesson completion affects it
+      queryClient.invalidateQueries({ queryKey: ['leaderboardEntries'] }); // Assuming 'leaderboardEntries' is a common key
+      // Invalidate user progress
+      queryClient.invalidateQueries({ queryKey: ['userProgress', variables.userId] });
+    },
+  });
+};
+
+// POST /api/users/:userId/equip-avatar
+export const useEquipAvatar = () => {
+  const queryClient = useQueryClient();
+  const { address, isConnected } = useAccount();
+
+  return useMutation<any, Error, { userId: string; payload: EquipAvatarPayload }>({
+    mutationFn: async ({ userId, payload }) => {
+      if (!isConnected || !address) {
+        throw new Error('User not connected');
+      }
+      const { data } = await apiClient.post(`/api/users/${userId}/equip-avatar`, payload);
+      return data;
+    },
+    onSuccess: (data, variables) => {
+      queryClient.invalidateQueries({ queryKey: [USER_QUERY_KEY, variables.userId] });
+    },
+  });
+};

--- a/packages/app/src/app/hooks/useUserProgressHooks.ts
+++ b/packages/app/src/app/hooks/useUserProgressHooks.ts
@@ -1,0 +1,127 @@
+// packages/app/src/app/hooks/useUserProgressHooks.ts
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import axios from 'axios';
+import { useAccount } from 'wagmi';
+import { API_URL } from '../config';
+
+// Types
+interface UserProgress {
+  id: string;
+  userId: string;
+  language: string;
+  lesson: number;
+  lastUpdated: Date;
+}
+
+interface CreateOrUpdateUserProgressPayload {
+  language: string;
+  lesson: number;
+}
+
+interface UpdateUserProgressPayload {
+  lesson: number;
+}
+
+const USER_PROGRESS_QUERY_KEY_PREFIX = 'userProgress';
+
+// Axios instance for API calls
+const apiClient = axios.create({
+  baseURL: API_URL,
+});
+
+// GET /api/users/:userId/progress - Get all progress for a user
+export const useGetUserProgressAll = (userId?: string) => {
+  const { address, isConnected } = useAccount();
+  const enabled = isConnected && !!userId;
+
+  return useQuery<UserProgress[], Error>({
+    queryKey: [USER_PROGRESS_QUERY_KEY_PREFIX, userId],
+    queryFn: async () => {
+      if (!userId) throw new Error('User ID is required');
+      const { data } = await apiClient.get(`/api/users/${userId}/progress`);
+      return data;
+    },
+    enabled: enabled,
+  });
+};
+
+// GET /api/users/:userId/progress/:language - Get specific language progress for a user
+export const useGetUserProgressByLanguage = (userId?: string, language?: string) => {
+  const { address, isConnected } = useAccount();
+  const enabled = isConnected && !!userId && !!language;
+
+  return useQuery<UserProgress, Error>({
+    queryKey: [USER_PROGRESS_QUERY_KEY_PREFIX, userId, language],
+    queryFn: async () => {
+      if (!userId || !language) throw new Error('User ID and language are required');
+      const { data } = await apiClient.get(`/api/users/${userId}/progress/${language}`);
+      return data;
+    },
+    enabled: enabled,
+  });
+};
+
+// POST /api/users/:userId/progress - Create or update user progress for a language
+export const useCreateOrUpdateUserProgress = () => {
+  const queryClient = useQueryClient();
+  const { address, isConnected } = useAccount();
+
+  return useMutation<UserProgress, Error, { userId: string; payload: CreateOrUpdateUserProgressPayload }>({
+    mutationFn: async ({ userId, payload }) => {
+      if (!isConnected || !address) {
+        throw new Error('User not connected');
+      }
+      const { data } = await apiClient.post(`/api/users/${userId}/progress`, payload);
+      return data;
+    },
+    onSuccess: (updatedProgress, variables) => {
+      queryClient.invalidateQueries({ queryKey: [USER_PROGRESS_QUERY_KEY_PREFIX, variables.userId] });
+      queryClient.invalidateQueries({ queryKey: [USER_PROGRESS_QUERY_KEY_PREFIX, variables.userId, updatedProgress.language] });
+      queryClient.setQueryData([USER_PROGRESS_QUERY_KEY_PREFIX, variables.userId, updatedProgress.language], updatedProgress);
+      // If user details query embeds progress, invalidate that too
+      queryClient.invalidateQueries({ queryKey: ['users', variables.userId] });
+    },
+  });
+};
+
+// PUT /api/users/:userId/progress/:language - Update user progress (e.g., advance lesson)
+export const useUpdateUserProgress = () => {
+  const queryClient = useQueryClient();
+  const { address, isConnected } = useAccount();
+
+  return useMutation<UserProgress, Error, { userId: string; language: string; payload: UpdateUserProgressPayload }>({
+    mutationFn: async ({ userId, language, payload }) => {
+      if (!isConnected || !address) {
+        throw new Error('User not connected');
+      }
+      const { data } = await apiClient.put(`/api/users/${userId}/progress/${language}`, payload);
+      return data;
+    },
+    onSuccess: (updatedProgress, variables) => {
+      queryClient.invalidateQueries({ queryKey: [USER_PROGRESS_QUERY_KEY_PREFIX, variables.userId] });
+      queryClient.invalidateQueries({ queryKey: [USER_PROGRESS_QUERY_KEY_PREFIX, variables.userId, variables.language] });
+      queryClient.setQueryData([USER_PROGRESS_QUERY_KEY_PREFIX, variables.userId, variables.language], updatedProgress);
+      queryClient.invalidateQueries({ queryKey: ['users', variables.userId] });
+    },
+  });
+};
+
+// DELETE /api/users/:userId/progress/:language - Delete specific language progress
+export const useDeleteUserProgress = () => {
+  const queryClient = useQueryClient();
+  const { address, isConnected } = useAccount();
+
+  return useMutation<void, Error, { userId: string; language: string }>({
+    mutationFn: async ({ userId, language }) => {
+      if (!isConnected || !address) {
+        throw new Error('User not connected');
+      }
+      await apiClient.delete(`/api/users/${userId}/progress/${language}`);
+    },
+    onSuccess: (data, variables) => {
+      queryClient.invalidateQueries({ queryKey: [USER_PROGRESS_QUERY_KEY_PREFIX, variables.userId] });
+      queryClient.invalidateQueries({ queryKey: [USER_PROGRESS_QUERY_KEY_PREFIX, variables.userId, variables.language] });
+      queryClient.invalidateQueries({ queryKey: ['users', variables.userId] });
+    },
+  });
+};


### PR DESCRIPTION
Created TanStack Query hooks for all backend API endpoint groups:
- User management (users, progress, avatars, badges, certificates)
- Avatar marketplace
- Leaderboard
- NFT metadata

Each hook integrates wagmi for wallet connection awareness and uses axios for HTTP requests. Hooks are organized by service under packages/app/src/app/hooks/.